### PR TITLE
Fix leak error in Mocha.

### DIFF
--- a/haversine.js
+++ b/haversine.js
@@ -14,7 +14,7 @@ var haversine = (function() {
     var km    = 6371
     options   = options || {}
 
-    R = options.unit === 'km' ? km : miles
+    var R = options.unit === 'km' ? km : miles
 
     var dLat = toRad(end.latitude - start.latitude)
     var dLon = toRad(end.longitude - start.longitude)


### PR DESCRIPTION
When running a unit test under the Mocha framework, assigning to globals
triggers the leak detector and (unless you specify the --ignore-leaks
flag) causes the test to fail. This diff fixes the declaration of R such
that it no longer triggers the leak detector. Note that this affects not
just tests directly testing this module, but any Mocha tests that test
modules with a dependency on Haversine.
