### PR TITLE
fix unit tests for haversine function

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -23,11 +23,11 @@ suite('haversine', function(){
     tests.forEach(function(t, i) {
         if (i === 0) {
             test('it should return ' + t[2] + ' mi for ' + t[0] + ' .. ' + t[1], function(){
-                assert.equal(Math.abs((haversine(t[0],t[1])-t[2])/t[2]).toFixed(2), "0.61")
+                assert.equal(Math.abs((haversine(t[0],t[1], {unit: 'mile'})-t[2])/t[2]).toFixed(2), "0.00")
             })
         } else {
             test('it should return ' + t[2] + ' km for ' + t[0] + ' .. ' + t[1], function(){
-                assert.equal(Math.abs((haversine(t[0],t[1])-t[2])/t[2], {unit: 'km'}).toFixed(2), "0.00")
+                assert.equal(Math.abs((haversine(t[0],t[1])-t[2])/t[2]).toFixed(2), "0.00")
             })
         }
     })


### PR DESCRIPTION
While I was adapting this handy script to my AngularJS project, I noticed that the unit tests didn't make a whole lot of sense to me. For starters, the options object wasn't being passed to the haversine function. Also, default units are in km, not miles, so only the first test needs the options parameter.
