### PR TITLE
Add format option 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "rules": {
-    "semi": [2, "never"]
+    "semi": [2, "never"],
     "no-mixed-spaces-and-tabs": 0,
     "indent": ["error", 2]
   }

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ A simple haversine formula module for Node.js
 #### api
 - `options.unit` - Unit of measurement applied to result (default `km`, available `km, mile, meter, nmi`)
 - `options.threshold` - If passed, will result in library returning `boolean` value of whether or not the start and end points are within that supplied threshold.  (default `null`)
+- `options.format` - The format of start and end coordinate arguments. See table below for available values. (default `null`)
+
+| Format        | Example
+| ------------- |--------------------------|
+| `undefined` (default) | `{ latitude: 30.849635, longitude: -83.24559] }`
+| `[lat,lon]`   | `[30.849635, -83.24559]`
+| `[lon,lat]`   | `[-83.24559, 30.849635]`
+| `{lat,lon}`   | `{ lat: 30.849635, lon: -83.24559] }`
+| `geojson`     | `{ type: 'Feature', geometry: { coordinates: [-83.24559, 30.849635] } }`
 
 
 [MIT License](http://opensource.org/licenses/MIT)

--- a/haversine.js
+++ b/haversine.js
@@ -5,7 +5,23 @@ var haversine = (function () {
     return num * Math.PI / 180
   }
 
-  return function haversine (start, end, options) {
+  // convert coordinates to standard format based on the passed format option
+  var convertCoordinates = function (format, coordinates) {
+    switch (format) {
+    case '[lat,lon]':
+      return { latitude: coordinates[0], longitude: coordinates[1] }
+    case '[lon,lat]':
+      return { latitude: coordinates[1], longitude: coordinates[0] }
+    case '{lon,lat}':
+      return { latitude: coordinates.lat, longitude: coordinates.lon }
+    case 'geojson':
+      return { latitude: coordinates.geometry.coordinates[1], longitude: coordinates.geometry.coordinates[0] }
+    default:
+      return coordinates
+    }
+  }
+
+  return function haversine (startCoordinates, endCoordinates, options) {
     options   = options || {}
 
     var radii = {
@@ -18,6 +34,9 @@ var haversine = (function () {
     var R = options.unit in radii
       ? radii[options.unit]
       : radii.km
+
+    var start = convertCoordinates(options.format, startCoordinates)
+    var end = convertCoordinates(options.format, endCoordinates)
 
     var dLat = toRad(end.latitude - start.latitude)
     var dLon = toRad(end.longitude - start.longitude)

--- a/haversine.js
+++ b/haversine.js
@@ -1,4 +1,10 @@
 var haversine = (function () {
+  var RADII = {
+    km:    6371,
+    mile:  3960,
+    meter: 6371000,
+    nmi:   3440
+  }
 
   // convert to radians
   var toRad = function (num) {
@@ -24,16 +30,9 @@ var haversine = (function () {
   return function haversine (startCoordinates, endCoordinates, options) {
     options   = options || {}
 
-    var radii = {
-      km:    6371,
-      mile:  3960,
-      meter: 6371000,
-      nmi:   3440
-    }
-
-    var R = options.unit in radii
-      ? radii[options.unit]
-      : radii.km
+    var R = options.unit in RADII
+      ? RADII[options.unit]
+      : RADII.km
 
     var start = convertCoordinates(options.format, startCoordinates)
     var end = convertCoordinates(options.format, endCoordinates)

--- a/test/test.js
+++ b/test/test.js
@@ -7,27 +7,57 @@ suite('haversine', function(){
       latitude: 38.898556,
       longitude: -77.037852
     }
+    var startLatLon = [38.898556, -77.037852]
+    var startLonLat = [-77.037852, 38.898556]
+    var startLatLonObject = {
+      lat: 38.898556,
+      lon: -77.037852
+    }
+    var startGeoJson = {
+      geometry: {
+        coordinates: [-77.037852, 38.898556]
+      }
+    }
 
     var end = {
       latitude: 38.897147,
       longitude: -77.043934
+    }
+    var endLatLon = [38.897147, -77.043934]
+    var endLonLat = [-77.043934, 38.897147]
+    var endLatLonObject = {
+      lat: 38.897147,
+      lon: -77.043934
+    }
+    var endGeoJson = {
+      geometry: {
+        coordinates: [-77.043934, 38.897147]
+      }
     }
 
     // All tests are rounded for sanity.
 
     var tests = [
         [start, end, 0.341],
-        [start, end, 0.549]
+        [start, end, 0.549],
+        [startLatLon, endLatLon, 0.341, { format: '[lat,lon]' }],
+        [startLatLon, endLatLon, 0.549, { format: '[lat,lon]' }],
+        [startLonLat, endLonLat, 0.341, { format: '[lon,lat]' }],
+        [startLonLat, endLonLat, 0.549, { format: '[lon,lat]' }],
+        [startLatLonObject, endLatLonObject, 0.341, { format: '{lon,lat}' }],
+        [startLatLonObject, endLatLonObject, 0.549, { format: '{lon,lat}' }],
+        [startGeoJson, endGeoJson, 0.341, { format: 'geojson' }],
+        [startGeoJson, endGeoJson, 0.549, { format: 'geojson' }],
     ]
 
     tests.forEach(function(t, i) {
-        if (i === 0) {
+        if (i % 2 === 0) {
             test('it should return ' + t[2] + ' mi for ' + t[0] + ' .. ' + t[1], function(){
-                assert.equal(Math.abs((haversine(t[0],t[1], {unit: 'mile'})-t[2])/t[2]).toFixed(2), "0.00")
+                assert.equal(Math.abs((haversine(t[0], t[1], Object.assign({unit: 'mile'}, t[3]))-t[2])/t[2]).toFixed(2), "0.00")
             })
         } else {
             test('it should return ' + t[2] + ' km for ' + t[0] + ' .. ' + t[1], function(){
-                assert.equal(Math.abs((haversine(t[0],t[1])-t[2])/t[2]).toFixed(2), "0.00")
+                assert.equal(Math.abs((haversine(t[0], t[1], Object.assign({}, t[3]))-t[2])/t[2]).toFixed(2), "0.00")
             })
         }
     })


### PR DESCRIPTION
This adds `options.format`, which lets the user specify which format the coordinates are in. The README is updated with the available values.

Tests are added for all the formats.

I also fixed a syntax error in  `.eslintrc`. (Missing comma).
