### PR TITLE
Fix documentation (formats)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ A simple haversine formula module for Node.js
 | `undefined` (default) | `{ latitude: 30.849635, longitude: -83.24559] }`
 | `[lat,lon]`   | `[30.849635, -83.24559]`
 | `[lon,lat]`   | `[-83.24559, 30.849635]`
-| `{lat,lon}`   | `{ lat: 30.849635, lon: -83.24559] }`
+| `{lon,lat}`   | `{ lat: 30.849635, lon: -83.24559] }`
+| `{lat,lng}`   | `{ lat: 30.849635, lng: -83.24559] }`
 | `geojson`     | `{ type: 'Feature', geometry: { coordinates: [-83.24559, 30.849635] } }`
 
 


### PR DESCRIPTION
You have an error in your documentation:

Format `{lat,lon}` is not supported, but `{lon,lat}` and `{lat,lng}` are.